### PR TITLE
File loader now skips files with leading "." even in sub directories.

### DIFF
--- a/lib/FileLoader.coffee
+++ b/lib/FileLoader.coffee
@@ -23,7 +23,7 @@ class FileLoader
       assetName = (((path.replace @jsFilesRoot, "").replace ".coffee", "").replace ".js", "").slice 1
 
       # Skip if a hidden file
-      return if assetName[0] == "."
+      return if "." == assetName.split("/")[assetName.split("/").length - 1][0]
       
       @log?("Assetizing #{assetName}")
       @assetJS assetName

--- a/test/jsprimer_spec.coffee
+++ b/test/jsprimer_spec.coffee
@@ -37,3 +37,4 @@ describe "FileLoader", ->
 
 		loader.loadFiles()
 		(".hidden.swp" in filesLoaded).should.equal false
+		("test/.hidden.swp" in filesLoaded).should.equal false


### PR DESCRIPTION
Your last change worked with files in the assets/js directory but if if you had a .**.swp.js file in a subdirectory it still caused problems. I updated your code with necessary changes and added files to the test.  
